### PR TITLE
write_table set correct size when write BIN fields

### DIFF
--- a/pyshtrih/commands.py
+++ b/pyshtrih/commands.py
@@ -139,22 +139,25 @@ def request_operational_register(self, num):
 request_operational_register.cmd = 0x1B
 
 
-def write_table(self, table, row, field, value, _type):
+def write_table(self, table, row, field, value, _type, _count=4):
     """
     Запись таблицы.
     """
 
-    cast_funcs_map = {
-        int: misc.FuncChain(bytearray, misc.int_to_bytes),
-        str: misc.encode
-    }
-
-    return self.protocol.command(
-        0x1E,
-        self.admin_password,
-        misc.CAST_SIZE['121'](table, row, field),
-        cast_funcs_map[_type](value)
-    )
+    if _type==str:
+        return self.protocol.command(
+            0x1E,
+            self.admin_password,
+            misc.CAST_SIZE['121'](table, row, field),
+            misc.encode(value)
+        )
+    else: # _type==int
+        return self.protocol.command(
+            0x1E,
+            self.admin_password,
+            misc.CAST_SIZE['121'](table, row, field),
+            bytearray(misc.int_to_bytes(value, count=_count))
+        )
 write_table.cmd = 0x1E
 
 


### PR DESCRIPTION
Процедура write_table устанавливала неверный размер полей BIN, т.к. в вызов misc.int_to_bytes не передавался корректный параметр count. Результатом становилась ошибка 0x33 в handle_payload, 180:protocol.py